### PR TITLE
#48 Refactor: 마이페이지 관련 코드 리팩토링 및 기능 연결

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -14,6 +14,7 @@ import { useProfileData } from "@/hooks/queries/useProfileData";
 import { useMypageRecommendEventData } from "@/hooks/queries/useMypageRecommendEventData";
 import { useLocationNameData } from "@/hooks/queries/useLocationNameData";
 import { useLocationStore } from "@/stores/locationStore";
+import { useRouter } from "next/navigation";
 
 export default function Mypage() {
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
@@ -30,6 +31,8 @@ export default function Mypage() {
     useLikedEventsData();
   const { data: plannedEvents, isLoading: isPlannedEventLoading } =
     usePlannedEventsData();
+
+  const router = useRouter();
 
   const weatherLocationInfo = {
     coords,
@@ -49,6 +52,10 @@ export default function Mypage() {
 
   const handleDetailClick = (eventId: string) => {
     setSelectedEventId(eventId);
+
+    const params = new URLSearchParams(window.location.search);
+    params.delete("date");
+    router.replace(`?${params.toString()}`, { scroll: false });
   };
 
   return (
@@ -73,7 +80,7 @@ export default function Mypage() {
         <aside className="order-2 flex flex-col gap-6 md:order-1 md:col-span-1 md:h-0 md:min-h-full">
           <Suspense
             fallback={
-              <div className="bg-muted min-h-[400px] w-full animate-pulse rounded-2xl" />
+              <div className="bg-muted min-h-100 w-full animate-pulse rounded-2xl" />
             }
           >
             <MypageEventSectionCard

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -6,7 +6,8 @@ import EventDetailModal from "@/components/map/EventDetailModal/EventDetailModal
 import MypageCalendarSection from "@/components/mypage/MypageCalendarSection";
 import MypageWeatherSection from "@/components/mypage/MypageWeatherSection";
 import MypageRecommendSection from "@/components/mypage/MypageRecommendSection";
-import { useState } from "react";
+import MypageEventCardSkeleton from "@/components/common/skeleton/MypageEventCardSkeleton";
+import { Suspense, useState } from "react";
 import { useLikedEventsData } from "@/hooks/queries/useLikedEventsData";
 import { usePlannedEventsData } from "@/hooks/queries/usePlannedEventsData";
 import { useProfileData } from "@/hooks/queries/useProfileData";
@@ -30,70 +31,76 @@ export default function Mypage() {
   const { data: plannedEvents, isLoading: isPlannedEventLoading } =
     usePlannedEventsData();
 
+  const weatherLocationInfo = {
+    coords,
+    isInitialized,
+    locationNameData,
+    isLocationError,
+    isLoading: isLocationLoading,
+    isDefaultLocation,
+  };
+
+  const isRecommendSectionLoading =
+    !profile?.id ||
+    !locationNameData ||
+    isRecommendEventCardLoading ||
+    isLikedEventLoading ||
+    isPlannedEventLoading;
+
   const handleDetailClick = (eventId: string) => {
     setSelectedEventId(eventId);
   };
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-4">
+      <section className="grid grid-cols-1 gap-6 md:grid-cols-4">
         <div className="md:col-span-1">
           <MypageProfileCard />
         </div>
-
         <div className="grid grid-cols-1 gap-6 md:col-span-3 md:grid-cols-2">
-          <MypageWeatherSection
-            coords={coords}
-            isInitialized={isInitialized}
-            locationNameData={locationNameData}
-            isLocationError={isLocationError}
-            isLoading={isLocationLoading}
-            isDefaultLocation={isDefaultLocation}
-          />
+          <MypageWeatherSection {...weatherLocationInfo} />
           <MypageRecommendSection
             recommendEventData={recommendEventData}
-            isLoading={
-              !profile?.id ||
-              !locationNameData ||
-              isRecommendEventCardLoading ||
-              isLikedEventLoading ||
-              isPlannedEventLoading
-            }
+            isLoading={isRecommendSectionLoading}
             likedEvents={likedEvents}
             plannedEvents={plannedEvents}
             onDetailClick={handleDetailClick}
           />
         </div>
-      </div>
+      </section>
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-4 md:items-stretch">
-        <div className="order-2 flex flex-col gap-6 md:order-1 md:col-span-1 md:h-0 md:min-h-full">
-          <div className="min-h-0 md:flex-1">
+      <section className="grid grid-cols-1 gap-6 md:grid-cols-4 md:items-stretch">
+        <aside className="order-2 flex flex-col gap-6 md:order-1 md:col-span-1 md:h-0 md:min-h-full">
+          <Suspense
+            fallback={
+              <div className="bg-muted min-h-[400px] w-full animate-pulse rounded-2xl" />
+            }
+          >
             <MypageEventSectionCard
-              title="나의 일정 목록"
+              title="일정 목록"
               iconName="bookmark"
               iconClassName="text-symbol-sky fill-symbol-sky"
               isLoading={isPlannedEventLoading}
               events={plannedEvents ?? []}
             />
-          </div>
-          <div className="min-h-0 md:flex-1">
             <MypageEventSectionCard
-              title="나의 관심 목록"
+              title="관심 목록"
               iconName="heart"
               iconClassName="text-red-500 fill-red-500"
               isLoading={isLikedEventLoading}
               events={likedEvents ?? []}
             />
-          </div>
+          </Suspense>
+        </aside>
+        <div className="order-1 md:order-2 md:col-span-3">
+          <MypageCalendarSection
+            plannedEvents={plannedEvents ?? []}
+            likedEvents={likedEvents ?? []}
+            profile={profile ?? undefined}
+            onDetailClick={handleDetailClick}
+          />
         </div>
-        <MypageCalendarSection
-          plannedEvents={plannedEvents ?? []}
-          likedEvents={likedEvents ?? []}
-          profile={profile ?? undefined}
-          onDetailClick={handleDetailClick}
-        />
-      </div>
+      </section>
 
       {selectedEventId && (
         <EventDetailModal

--- a/src/app/api/mypage/recommend/route.ts
+++ b/src/app/api/mypage/recommend/route.ts
@@ -1,6 +1,5 @@
 import { CATEGORY_NAME_MAP } from "@/lib/constants";
 import { Event } from "@/types/common";
-import { Tables } from "@/types/supabase";
 import { getKstNow } from "@/utils/date";
 import { createClient } from "@/utils/supabase/server";
 import { transformEvent } from "@/utils/transform";
@@ -214,7 +213,15 @@ export async function POST(request: Request) {
     const completion = await openai.chat.completions.create({
       model: "gpt-4.1-mini",
       response_format: { type: "json_object" },
-      messages: [{ role: "user", content: prompt }],
+      messages: [
+        {
+          role: "system",
+          content:
+            "당신은 한국의 축제와 행사를 전문적으로 추천하는 유능한 비서입니다.",
+        },
+        { role: "user", content: prompt },
+      ],
+      temperature: 0.7,
     });
 
     const aiResult = JSON.parse(completion.choices[0].message.content || "{}");

--- a/src/app/api/remind/route.ts
+++ b/src/app/api/remind/route.ts
@@ -7,8 +7,13 @@ import { NextResponse } from "next/server";
 import nodemailer from "nodemailer";
 
 export async function GET(req: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    console.error("Missing CRON_SECRET");
+    return new Response("Server misconfigured", { status: 500 });
+  }
   const authHeader = req.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (authHeader !== `Bearer ${cronSecret}`) {
     return new Response("Unauthorized", { status: 401 });
   }
 

--- a/src/app/api/remind/route.ts
+++ b/src/app/api/remind/route.ts
@@ -1,7 +1,7 @@
 import { Database } from "@/types/supabase";
 import { getKstNow } from "@/utils/date";
 import { createClient, QueryData } from "@supabase/supabase-js";
-import { addDays, format } from "date-fns";
+import { addDays, format, parseISO } from "date-fns";
 import { ko } from "date-fns/locale";
 import { NextResponse } from "next/server";
 import nodemailer from "nodemailer";
@@ -23,7 +23,6 @@ export async function GET(req: Request) {
   );
 
   try {
-    // 배포 이후 Vercel에서 TZ: Asia/Seoul 설정만 해두면 new Date() 써도 문제없음
     const targetDate = format(addDays(getKstNow(), 7), "yyyy-MM-dd");
 
     const query = supabase
@@ -66,26 +65,30 @@ export async function GET(req: Request) {
       },
     });
 
+    let attempted = 0;
+    let skipped = 0;
+    let failed = 0;
+    const failures: unknown[] = [];
+
     const sendResults = await Promise.allSettled(
       (list as ReminderItems).map(async (item) => {
-        if (!item.visit_date) return;
+        if (!item.visit_date)
+          return { type: "skipped", reason: "Missing visit_date" };
 
         const profile = Array.isArray(item.profiles)
           ? item.profiles[0]
           : item.profiles;
         const e = Array.isArray(item.events) ? item.events[0] : item.events;
 
-        if (!profile || !e) return;
+        if (!profile || !e)
+          return { type: "skipped", reason: "Missing profile or event data" };
 
-        const { email, nickname } = profile;
         const displayVisitDate = format(
-          new Date(item.visit_date),
+          parseISO(item.visit_date),
           "M월 d일 (eeee)",
-          {
-            locale: ko,
-          },
+          { locale: ko },
         );
-
+        const { email, nickname } = profile;
         const dateParam = item.visit_date;
         const monthParam = item.visit_date.slice(0, 7);
         const fullAddress =
@@ -93,11 +96,12 @@ export async function GET(req: Request) {
           "주소 정보 없음";
         const mypageUrl = `${process.env.NEXT_PUBLIC_SITE_URL}/mypage?date=${dateParam}&month=${monthParam}`;
 
-        return transporter.sendMail({
-          from: `갈래말래 <${process.env.GOOGLE_USER}>`,
-          to: email,
-          subject: `[D-7] ${nickname}님, '${e.name}' 방문 일주일 전입니다!`,
-          html: `
+        try {
+          await transporter.sendMail({
+            from: `갈래말래 <${process.env.GOOGLE_USER}>`,
+            to: email,
+            subject: `[D-7] ${nickname}님, '${e.name}' 방문 일주일 전입니다!`,
+            html: `
             <div style="max-width: 560px; margin: 0 auto; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif; background-color: #ffffff; border: 1px solid #ebebeb; border-radius: 20px; overflow: hidden;">
               <div style="background-color: #0da3e4; padding: 40px 24px; text-align: center;">
                 <h1 style="color: #ffffff; margin: 0; font-size: 28px; line-height: 1.3; font-weight: 600;">방문 리마인드 알림</h1>
@@ -169,15 +173,46 @@ export async function GET(req: Request) {
               </div>
             </div>
           `,
-        });
+          });
+
+          return { type: "sent", to: email };
+        } catch (err) {
+          throw err;
+        }
       }),
     );
 
-    return NextResponse.json({
-      message: "발송 작업 완료",
-      total: list.length,
-      results: sendResults.map((result) => result.status),
+    sendResults.forEach((result) => {
+      if (result.status === "fulfilled") {
+        // 성공한 프로미스 중 'skipped'와 'sent' 구분
+        if (result.value.type === "skipped") {
+          skipped++;
+        } else {
+          attempted++; // 실제 발송 시도(성공)
+        }
+      } else {
+        failed++;
+        attempted++; // 발송을 시도했으나 실패함
+        failures.push(result.reason);
+      }
     });
+
+    // 실패 건수가 하나라도 있으면 500 혹은 207(Multi-Status) 반환
+    const status = failed > 0 ? 500 : 200;
+
+    return NextResponse.json(
+      {
+        message: failed > 0 ? "일부 발송 실패 발생" : "작업 완료",
+        metrics: {
+          total_records: list.length,
+          sent: attempted - failed,
+          skipped: skipped,
+          failed: failed,
+        },
+        errors: failures.length > 0 ? failures : undefined,
+      },
+      { status },
+    );
   } catch (error: unknown) {
     const errorMessage =
       error instanceof Error

--- a/src/app/api/remind/route.ts
+++ b/src/app/api/remind/route.ts
@@ -6,12 +6,11 @@ import { ko } from "date-fns/locale";
 import { NextResponse } from "next/server";
 import nodemailer from "nodemailer";
 
-export async function GET() {
-  // 해당 부분 보안 로직은 Vercel에서 CRON_SECRET 발급받아서 적용시 사용
-  // const authHeader = req.headers.get("authorization");
-  // if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-  //   return new Response("Unauthorized", { status: 401 });
-  // }
+export async function GET(req: Request) {
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
 
   const supabase = createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -26,21 +25,31 @@ export async function GET() {
       .from("event_plans")
       .select(
         `
+        visit_date,
         profiles:user_id ( email, nickname ),
-        events:event_id!inner ( 
-          name, venue, start_date, road_address, lot_address, phone, homepage_url, organizer 
+        events:event_id ( 
+          name, 
+          venue, 
+          start_date, 
+          phone, 
+          homepage_url, 
+          organization,
+          sido,
+          sigungu,
+          eupmyeondong
         )
       `,
       )
-      .eq("events.start_date", targetDate);
+      .eq("visit_date", targetDate);
 
     type ReminderItems = QueryData<typeof query>;
+
     const { data: list, error } = await query;
 
     if (error) throw error;
     if (!list || list.length === 0) {
       return NextResponse.json({
-        message: `${targetDate} 행사 시작 대상 없음`,
+        message: `${targetDate} 방문 예정 대상 없음`,
       });
     }
 
@@ -54,7 +63,8 @@ export async function GET() {
 
     const sendResults = await Promise.allSettled(
       (list as ReminderItems).map(async (item) => {
-        // Supabase 조인은 결과가 배열로 나와서 인덱스로 첫 요소 선택
+        if (!item.visit_date) return;
+
         const profile = Array.isArray(item.profiles)
           ? item.profiles[0]
           : item.profiles;
@@ -63,47 +73,65 @@ export async function GET() {
         if (!profile || !e) return;
 
         const { email, nickname } = profile;
-        const displayDate = format(new Date(e.start_date), "M월 d일 (eeee)", {
-          locale: ko,
-        });
-        const address =
-          e.road_address || e.lot_address || "상세 주소 정보 없음";
+        const displayVisitDate = format(
+          new Date(item.visit_date),
+          "M월 d일 (eeee)",
+          {
+            locale: ko,
+          },
+        );
+
+        const dateParam = item.visit_date;
+        const monthParam = item.visit_date.slice(0, 7);
+        const fullAddress =
+          [e.sido, e.sigungu, e.eupmyeondong].filter(Boolean).join(" ") ||
+          "주소 정보 없음";
+        const mypageUrl = `${process.env.NEXT_PUBLIC_SITE_URL}/mypage?date=${dateParam}&month=${monthParam}`;
 
         return transporter.sendMail({
           from: `갈래말래 <${process.env.GOOGLE_USER}>`,
           to: email,
-          subject: `[D-7] ${nickname}님, '${e.name}'가 일주일 앞으로 다가왔습니다!`,
+          subject: `[D-7] ${nickname}님, '${e.name}' 방문 일주일 전입니다!`,
           html: `
             <div style="max-width: 560px; margin: 0 auto; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif; background-color: #ffffff; border: 1px solid #ebebeb; border-radius: 20px; overflow: hidden;">
               <div style="background-color: #0da3e4; padding: 40px 24px; text-align: center;">
-                <h1 style="color: #ffffff; margin: 0; font-size: 28px; line-height: 1.3; font-weight: 600;">행사 리마인드 알림</h1>
+                <h1 style="color: #ffffff; margin: 0; font-size: 28px; line-height: 1.3; font-weight: 600;">방문 리마인드 알림</h1>
               </div>
               
               <div style="padding: 40px 32px; color: #333333;">
                 <p style="font-size: 20px; font-weight: 600; margin-bottom: 24px;">안녕하세요, ${nickname}님!</p>
                 <p style="font-size: 16px; line-height: 1.6; color: #444444; margin-bottom: 32px;">
-                  설레는 마음으로 기다리시던 <b>${e.name}</b> 행사가 어느덧 일주일 뒤로 다가왔습니다. 잊지 않으시도록 정보를 정리해 드려요.
+                  일정에 추가하셨던 <b>${e.name}</b> 방문일이 일주일 앞으로 다가왔습니다.
                 </p>
                 
                 <div style="background-color: #e7f6fc; border-left: 4px solid #0da3e4; border-radius: 8px; padding: 24px; margin-bottom: 32px;">
-                  <h3 style="margin: 0 0 16px 0; color: #0da3e4; font-size: 20px; font-weight: 600;">📍 행사 상세 정보</h3>
+                  <h3 style="margin: 0 0 16px 0; color: #0da3e4; font-size: 20px; font-weight: 600;">📍 방문 예정 정보</h3>
                   <table style="width: 100%; border-collapse: collapse; font-size: 16px;">
                     <tr>
                       <td style="padding: 8px 0; color: #666666; width: 80px; vertical-align: top; font-size: 14px;"><b>행사명</b></td>
                       <td style="padding: 8px 0 8px 16px; color: #111111; font-weight: 500;">${e.name}</td>
                     </tr>
                     <tr>
-                      <td style="padding: 8px 0; color: #666666; vertical-align: top; font-size: 14px;"><b>일시</b></td>
-                      <td style="padding: 8px 0 8px 16px; color: #111111;">${displayDate}</td>
+                      <td style="padding: 8px 0; color: #666666; vertical-align: top; font-size: 14px;"><b>방문 예정일</b></td>
+                      <td style="padding: 8px 0 8px 16px; color: #111111; font-weight: 600;">${displayVisitDate}</td>
                     </tr>
                     <tr>
                       <td style="padding: 8px 0; color: #666666; vertical-align: top; font-size: 14px;"><b>장소</b></td>
-                      <td style="padding: 8px 0 8px 16px; color: #111111;">${e.venue}</td>
+                      <td style="padding: 8px 0 8px 16px; color: #111111;">${e.venue || "정보 없음"}</td>
                     </tr>
                     <tr>
                       <td style="padding: 8px 0; color: #666666; vertical-align: top; font-size: 14px;"><b>주소</b></td>
-                      <td style="padding: 8px 0 8px 16px; color: #111111;">${address}</td>
+                      <td style="padding: 8px 0 8px 16px; color: #111111;">${fullAddress}</td>
                     </tr>
+                    ${
+                      e.organization
+                        ? `
+                    <tr>
+                      <td style="padding: 8px 0; color: #666666; vertical-align: top; font-size: 14px;"><b>주최</b></td>
+                      <td style="padding: 8px 0 8px 16px; color: #111111;">${e.organization}</td>
+                    </tr>`
+                        : ""
+                    }
                     ${
                       e.homepage_url
                         ? `
@@ -128,17 +156,10 @@ export async function GET() {
                 </div>
 
                 <div style="text-align: center; margin-top: 40px;">
-                  <a href="${process.env.NEXT_PUBLIC_SITE_URL || "https://gallaemallae.vercel.app"}/mypage" 
+                  <a href="${mypageUrl}" 
                     style="background-color: #0da3e4; color: #ffffff; padding: 16px 40px; text-decoration: none; border-radius: 12px; font-weight: 700; font-size: 16px; display: inline-block;">
-                    내 일정 자세히 보기
+                    내 일정 확인하기
                   </a>
-                </div>
-              </div>
-
-              <div style="background-color: #f9fafb; padding: 32px; text-align: center; border-top: 1px solid #ebebeb;">
-                <p style="margin: 0; font-size: 12px; color: #666666; line-height: 1.4;">본 메일은 시스템에 의해 자동 발송된 메시지입니다.</p>
-                <div style="margin-top: 16px;">
-                  <span style="font-weight: 700; color: #0da3e4; font-size: 14px;">갈래말래 Gallaemallae</span>
                 </div>
               </div>
             </div>
@@ -161,14 +182,3 @@ export async function GET() {
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }
-
-// Vercel 배포 시 프로젝트 루트 디렉토리에 vercel.json 파일에 넣어줘야 함
-// 밤 12시 넘어가면 remind 호출해서 메일 보내는 crons
-// {
-//   "crons": [
-//     {
-//       "path": "/api/remind",
-//       "schedule": "0 0 * * *"
-//     }
-//   ]
-// }

--- a/src/components/common/MoreCard.tsx
+++ b/src/components/common/MoreCard.tsx
@@ -6,6 +6,7 @@ export default function MoreCard({ onClick }: { onClick: () => void }) {
     <Card
       className="cursor-pointer rounded-2xl"
       role="button"
+      tabIndex={0}
       onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/src/components/modal/VisitDateModal.tsx
+++ b/src/components/modal/VisitDateModal.tsx
@@ -84,13 +84,18 @@ export default function VisitDateModal() {
             locale={ko}
             autoFocus
           />
+          {!date && (
+            <p className="text-destructive text-caption mt-2">
+              방문하실 날짜를 달력에서 선택해 주세요.
+            </p>
+          )}
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={close}>
             취소
           </Button>
-          <Button onClick={handleConfirm} disabled={isPending}>
+          <Button onClick={handleConfirm} disabled={isPending || !date}>
             {isPending ? "추가 중..." : "확인"}
           </Button>
         </DialogFooter>

--- a/src/components/mypage/MypageAgendaCard.tsx
+++ b/src/components/mypage/MypageAgendaCard.tsx
@@ -47,8 +47,15 @@ export default function MypageAgendaCard({
   return (
     <div
       role="button"
+      tabIndex={0}
       className="hover:bg-muted flex cursor-pointer flex-col gap-1 rounded-xl p-2"
       onClick={handleCardClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleCardClick();
+        }
+      }}
     >
       <div className="flex items-center justify-between">
         <div className="flex h-6 min-w-0 flex-1 flex-wrap gap-1 overflow-hidden">

--- a/src/components/mypage/MypageAgendaCard.tsx
+++ b/src/components/mypage/MypageAgendaCard.tsx
@@ -51,14 +51,13 @@ export default function MypageAgendaCard({
       onClick={handleCardClick}
     >
       <div className="flex items-center justify-between">
-        <div className="flex gap-2">
+        <div className="flex h-6 min-w-0 flex-1 flex-wrap gap-1 overflow-hidden">
           {event.categories?.map((category, index) => {
             const label = CATEGORY_NAME_MAP[category as CategoryId] || "기타";
-
             return (
               <Badge
                 key={`${category}-${index}`}
-                className="shrink-0 rounded-sm"
+                className="truncate rounded-sm"
                 variant={label}
               >
                 {label}
@@ -66,8 +65,10 @@ export default function MypageAgendaCard({
             );
           })}
         </div>
-        <div className="flex items-center gap-2">
-          <div className="text-desc2 text-symbol-sky font-semibold">{dDay}</div>
+        <div className="flex shrink-0 items-center gap-2">
+          <div className="text-desc2 text-symbol-sky font-semibold whitespace-nowrap">
+            {dDay}
+          </div>
           <Trash2Icon
             size={18}
             className={cn(

--- a/src/components/mypage/MypageAgendaCard.tsx
+++ b/src/components/mypage/MypageAgendaCard.tsx
@@ -1,20 +1,17 @@
 import { Badge } from "@/components/ui/badge";
-import { CalendarCheck, CalendarClock, Trash2Icon } from "lucide-react";
+import { CalendarCheck, Trash2Icon } from "lucide-react";
 import { useDeleteEventPlan } from "@/hooks/mutations/useDeleteEventPlan";
 import { CATEGORY_NAME_MAP } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { useOpenAlertModal } from "@/stores/alertModalStore";
-import { MypageDisplayEvent } from "@/types/common";
+import { CategoryId, MypageDisplayEvent } from "@/types/common";
 import { calculateDDay } from "@/utils/date";
 
 interface MypageAgendaCardProps {
   event: MypageDisplayEvent;
-  selectedDate?: string;
   onClick?: () => void;
   onDetailClick?: (eventId: string) => void;
 }
-
-export type CategoryKey = keyof typeof CATEGORY_NAME_MAP;
 
 export default function MypageAgendaCard({
   event,
@@ -23,15 +20,15 @@ export default function MypageAgendaCard({
 }: MypageAgendaCardProps) {
   const { mutate: deletePlan, isPending: isDeletePlanLoading } =
     useDeleteEventPlan();
+
   const openAlert = useOpenAlertModal();
-  const dDay = calculateDDay(event.visit_date || event.start_date);
+
+  const displayDate = event.visit_date || event.start_date;
+  const dDay = calculateDDay(displayDate);
 
   const handleCardClick = () => {
-    if (onDetailClick) {
-      onDetailClick(event.id);
-    } else if (onClick) {
-      onClick();
-    }
+    if (onDetailClick) return onDetailClick(event.id);
+    onClick?.();
   };
 
   const handleDeleteClick = (e: React.MouseEvent) => {
@@ -39,34 +36,32 @@ export default function MypageAgendaCard({
     e.stopPropagation();
 
     if (event.plan_id) {
-      const planId = event.plan_id;
-
       openAlert({
         title: "일정에서 제거하기",
         description: `${event.name}를 일정에서 제거하시겠습니까?`,
-        onAction: () => deletePlan(planId),
+        onAction: () => deletePlan(event.plan_id!),
       });
     }
   };
 
   return (
     <div
+      role="button"
       className="hover:bg-muted flex cursor-pointer flex-col gap-1 rounded-xl p-2"
       onClick={handleCardClick}
     >
       <div className="flex items-center justify-between">
         <div className="flex gap-2">
-          {event.categories?.map((category) => {
-            const categoryLabel =
-              CATEGORY_NAME_MAP[category as CategoryKey] || "기타";
+          {event.categories?.map((category, index) => {
+            const label = CATEGORY_NAME_MAP[category as CategoryId] || "기타";
 
             return (
               <Badge
-                key={category}
+                key={`${category}-${index}`}
                 className="shrink-0 rounded-sm"
-                variant={categoryLabel}
+                variant={label}
               >
-                {CATEGORY_NAME_MAP[category as CategoryKey] || "기타"}
+                {label}
               </Badge>
             );
           })}
@@ -89,8 +84,7 @@ export default function MypageAgendaCard({
         <div className="text-desc2 text-etc flex items-center gap-2 truncate">
           <CalendarCheck className="size-4 shrink-0 -translate-y-px" />
           <span className="truncate">
-            {event.visit_date ? event.visit_date : event.start_date} /{" "}
-            {event.venue}
+            {displayDate} / {event.venue}
           </span>
         </div>
       </div>

--- a/src/components/mypage/MypageCalendar.tsx
+++ b/src/components/mypage/MypageCalendar.tsx
@@ -34,18 +34,12 @@ import {
   differenceInCalendarDays,
   format,
   isSameDay,
-  parseISO,
   startOfDay,
   startOfWeek,
 } from "date-fns";
 import { MypageDisplayEvent } from "@/types/common";
 import { ScrollArea } from "@/components/ui/scroll-area";
-
-interface ProcessedEvent extends MypageDisplayEvent {
-  _start: Date;
-  _end: Date;
-  _id: string;
-}
+import { getWeeklyEventSlots, ProcessedEvent } from "@/utils/calendar";
 
 type CategoryKey = keyof typeof CATEGORY_NAME_MAP;
 const MAX_EVENTS = 3;
@@ -74,88 +68,12 @@ const CalendarContext = React.createContext<{
   viewMode: "plan" | "like";
   weeklyEventSlots: Record<string, Record<string, number>>;
   processedEvents: ProcessedEvent[];
+  dailyEventsMap: Record<string, ProcessedEvent[]>;
   onActivePopoverDate: (date: Date | null) => void;
   onViewModeChange: (viewMode: "plan" | "like") => void;
   onMonthChange?: (newMonth: Date) => void;
   onDetailClick: (eventId: string) => void;
 } | null>(null);
-
-// 주차별 행사의 슬롯 번호 계산하는 함수
-const getWeeklyEventSlots = (events: MypageDisplayEvent[]) => {
-  if (events.length === 0) return { processedEvents: [], weeklySlots: {} };
-
-  // 데이터 전처리(파싱, Date 객체 변환) 및 정렬
-  const processedEvents = events
-    .map((event) => ({
-      ...event,
-      _start: startOfDay(parseISO(event.start_date)),
-      _end: startOfDay(parseISO(event.end_date)),
-      _id: String(event.plan_id || event.id),
-    }))
-    .sort((a, b) => {
-      const diff = a._start.getTime() - b._start.getTime();
-      if (diff !== 0) return diff;
-      // 시작일이 같으면 기간이 긴 순서대로
-      return (
-        b._end.getTime() -
-        b._start.getTime() -
-        (a._end.getTime() - a._start.getTime())
-      );
-    });
-
-  // 주차별로 이벤트 그룹화
-  const weekBuckets: Record<string, typeof processedEvents> = {};
-
-  processedEvents.forEach((event) => {
-    let currentWeekStart = startOfWeek(event._start);
-    const lastWeekStart = startOfWeek(event._end);
-
-    while (currentWeekStart <= lastWeekStart) {
-      const weekKey = currentWeekStart.getTime().toString();
-      if (!weekBuckets[weekKey]) weekBuckets[weekKey] = [];
-      weekBuckets[weekKey].push(event);
-      currentWeekStart = addDays(currentWeekStart, 7);
-    }
-  });
-
-  // 각 주차별로 슬롯 번호 배정
-  const weeklySlots: Record<string, Record<string, number>> = {};
-
-  Object.entries(weekBuckets).forEach(([weekKey, weekEvents]) => {
-    const slots: Record<string, number> = {}; //{행사 ID, 슬롯 번호}
-    const occupation: { start: number; end: number }[][] = [];
-
-    weekEvents.forEach((event) => {
-      const startTs = event._start.getTime();
-      const endTs = event._end.getTime();
-      let assignedSlot = -1;
-
-      // 이미 정렬된 상태이므로 순서대로 슬롯 찾기
-      for (let i = 0; i < occupation.length; i++) {
-        const hasOverlap = occupation[i].some(
-          (occ) => startTs <= occ.end && endTs >= occ.start,
-        );
-        if (!hasOverlap) {
-          assignedSlot = i;
-          break;
-        }
-      }
-
-      // 들어갈 층이 없는 경우 새 층을 추가하고 push
-      if (assignedSlot === -1) {
-        assignedSlot = occupation.length;
-        occupation.push([]);
-      }
-
-      occupation[assignedSlot].push({ start: startTs, end: endTs });
-      slots[event._id] = assignedSlot;
-    });
-
-    weeklySlots[weekKey] = slots;
-  });
-
-  return { processedEvents, weeklySlots };
-};
 
 function MypageCalendar({
   viewMode,
@@ -217,7 +135,7 @@ function MypageCalendar({
     [],
   );
 
-  const { processedEvents, weeklySlots } = React.useMemo(
+  const { processedEvents, weeklySlots, dailyEventsMap } = React.useMemo(
     () => getWeeklyEventSlots(calendarDisplayEvents),
     [calendarDisplayEvents],
   );
@@ -232,6 +150,7 @@ function MypageCalendar({
         viewMode,
         weeklyEventSlots: weeklySlots,
         processedEvents,
+        dailyEventsMap,
         onActivePopoverDate: onActivePopoverDate ?? (() => {}),
         onDetailClick,
         onMonthChange,
@@ -333,21 +252,17 @@ function CalendarDayButton({
     isDesktop,
     viewMode,
     weeklyEventSlots,
-    processedEvents,
+    dailyEventsMap,
     onDetailClick,
     onActivePopoverDate,
   } = context;
 
   const targetDate = startOfDay(day.date);
-  const targetTime = targetDate.getTime();
+  const targetTimeKey = targetDate.getTime().toString();
   const weekKey = startOfWeek(targetDate).getTime().toString();
   const currentWeekSlots = weeklyEventSlots[weekKey] || {};
 
-  const dayEvents = processedEvents.filter((event) => {
-    return (
-      targetTime >= event._start.getTime() && targetTime <= event._end.getTime()
-    );
-  });
+  const dayEvents = dailyEventsMap[targetTimeKey] || [];
 
   const fluidHeight =
     "@[100px]:h-[clamp(4px,18cqw,36px)] h-[clamp(4px,10cqw,36px)]";

--- a/src/components/mypage/MypageCalendar.tsx
+++ b/src/components/mypage/MypageCalendar.tsx
@@ -485,7 +485,6 @@ function CalendarDayButton({
           <ScrollArea className="*:data-[slot=scroll-area-viewport]:max-h-96">
             <div className="p-6">
               <MypageSelectedDateEventsCard
-                selectedDate={activePopoverDate ?? null}
                 events={dayEvents}
                 viewMode={viewMode}
                 onDetailClick={onDetailClick}
@@ -612,8 +611,8 @@ function CustomMonthCaption({
         )}
         <span className="text-title2 md:text-title1 font-bold">
           {viewMode === "plan"
-            ? `${ownerLabel} 일정 목록`
-            : `${ownerLabel} 관심 목록`}
+            ? `${ownerLabel} 일정`
+            : `${ownerLabel} 관심 행사`}
         </span>
       </div>
 

--- a/src/components/mypage/MypageCalendar.tsx
+++ b/src/components/mypage/MypageCalendar.tsx
@@ -383,6 +383,7 @@ function CalendarDayButton({
           className="w-full min-w-100 overflow-hidden p-0"
           align="start"
           side="bottom"
+          onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <div className="p-6">
             <div className="text-desc1 font-bold">
@@ -485,13 +486,7 @@ function CustomMonthCaption({
 
   const context = React.useContext(CalendarContext);
   if (!context) return <></>;
-  const {
-    nickname,
-    onMonthChange,
-    onActivePopoverDate,
-    viewMode,
-    onViewModeChange,
-  } = context;
+  const { nickname, onMonthChange, viewMode, onViewModeChange } = context;
 
   const date = calendarMonth.date;
   const y = date.getFullYear();

--- a/src/components/mypage/MypageCalendar.tsx
+++ b/src/components/mypage/MypageCalendar.tsx
@@ -440,7 +440,12 @@ const EventSlotItem = ({
   const shouldTruncateToday = isSaturday || isEnd;
 
   return (
-    <div className={cn("relative w-full overflow-visible", fluidHeight)}>
+    <div
+      className={cn(
+        "pointer-events-none relative w-full overflow-visible",
+        fluidHeight,
+      )}
+    >
       {/* 배경색 막대 */}
       <div
         className={cn(

--- a/src/components/mypage/MypageCalendarSection.tsx
+++ b/src/components/mypage/MypageCalendarSection.tsx
@@ -152,7 +152,6 @@ export default function MypageCalendarSection({
             <div className="flex h-[60dvh] max-h-128 w-full flex-col justify-center p-6">
               <ScrollArea className="min-h-0 flex-1">
                 <MypageSelectedDateEventsCard
-                  selectedDate={selectedDate}
                   events={dailyEvents}
                   viewMode={viewMode}
                   onDetailClick={onDetailClick}

--- a/src/components/mypage/MypageCalendarSection.tsx
+++ b/src/components/mypage/MypageCalendarSection.tsx
@@ -6,7 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 import { useIsDesktop } from "@/hooks/useIsDesktop";
 import { Event, EventPlanWithEvent, Profile } from "@/types/common";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   format,
   isWithinInterval,
@@ -79,20 +79,7 @@ export default function MypageCalendarSection({
     });
   }, [selectedDate, calendarDisplayEvents]);
 
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [prevDateParam, setPrevDateParam] = useState<string | null>(dateParam);
-
-  if (dateParam !== prevDateParam) {
-    setPrevDateParam(dateParam);
-
-    const hasEvents = dailyEvents.length > 0;
-
-    if (!isDesktop && dateParam && hasEvents) {
-      setIsDrawerOpen(true);
-    } else if (!dateParam) {
-      setIsDrawerOpen(false);
-    }
-  }
+  const isDrawerOpen = !isDesktop && !!dateParam && dailyEvents.length > 0;
 
   const updateURL = (date?: Date, month?: Date, mode?: CalendarMode) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -120,7 +107,6 @@ export default function MypageCalendarSection({
     updateURL(date ?? undefined);
   };
   const handleDrawerChange = (open: boolean) => {
-    setIsDrawerOpen(open);
     if (!open) updateURL(undefined);
   };
 
@@ -146,7 +132,12 @@ export default function MypageCalendarSection({
       </div>
 
       {!isDesktop && (
-        <Drawer open={isDrawerOpen} onOpenChange={handleDrawerChange}>
+        <Drawer
+          open={isDrawerOpen}
+          onOpenChange={(open) => {
+            if (!open) handleDrawerChange(false);
+          }}
+        >
           <DrawerTitle className="sr-only">선택한 날짜 일정</DrawerTitle>
           <DrawerContent>
             <div className="flex h-[60dvh] max-h-128 w-full flex-col justify-center p-6">

--- a/src/components/mypage/MypageEventRecommendCard.tsx
+++ b/src/components/mypage/MypageEventRecommendCard.tsx
@@ -30,27 +30,37 @@ export default function MypageEventRecommendCard({
 }: MypageEventRecommendCardProps) {
   const { data: profile } = useProfileData();
 
-  const { mutate: toggleLike } = useEventLike(event.id);
-  const { mutate: deletePlan, isPending: isDeletePlanLoading } =
+  const { mutate: toggleLike, isPending: isLikePending } = useEventLike(
+    event.id,
+  );
+  const { mutate: deletePlan, isPending: isDeletePlanPending } =
     useDeleteEventPlan();
 
   const openAlert = useOpenAlertModal();
   const openVisitDateModal = useOpenVisitDateModal();
 
+  const checkProfile = () => {
+    if (!profile?.id) {
+      toast.error("프로필 정보가 없습니다.");
+      return false;
+    }
+    return true;
+  };
+
   const handleLikeClick = () => {
+    if (isLikePending) return;
     toggleLike(isLiked);
   };
 
   const handleAddPlanClick = () => {
-    if (!profile?.id) return toast.error("프로필 정보가 없습니다.");
+    if (!checkProfile()) return;
     openVisitDateModal({
       event: event,
     });
   };
 
   const handleDeletePlanClick = () => {
-    if (!profile?.id) return toast.error("프로필 정보가 없습니다.");
-    if (!planId) return;
+    if (!checkProfile() || !planId) return;
 
     openAlert({
       title: "일정에서 제거하기",
@@ -68,11 +78,12 @@ export default function MypageEventRecommendCard({
           size="icon"
           aria-label="좋아요"
           aria-pressed={isLiked}
+          disabled={isLikePending}
           onClick={() => handleLikeClick()}
         >
           <Heart
             className={cn(
-              "h-5 w-5",
+              "size-5",
               isLiked ? "fill-red-500 text-red-500" : "text-etc",
             )}
           />
@@ -87,34 +98,30 @@ export default function MypageEventRecommendCard({
         <div className="mb-2 flex items-center gap-2">
           <h3 className="text-title2 font-bold">{event.name}</h3>
           <div className="flex items-center gap-1">
-            {event.categories.map((category) => (
-              <Badge
-                key={category}
-                className="rounded-sm"
-                variant={
-                  CATEGORY_NAME_MAP[
-                    category as keyof typeof CATEGORY_NAME_MAP
-                  ] || category
-                }
-              >
-                {CATEGORY_NAME_MAP[
-                  category as keyof typeof CATEGORY_NAME_MAP
-                ] || category}
-              </Badge>
-            ))}
+            {event.categories.map((category) => {
+              const label =
+                CATEGORY_NAME_MAP[category as keyof typeof CATEGORY_NAME_MAP] ||
+                "기타";
+
+              return (
+                <Badge key={category} className="rounded-sm" variant={label}>
+                  {label}
+                </Badge>
+              );
+            })}
           </div>
         </div>
 
         <div className="text-desc2 text-etc mb-2 flex flex-col">
           <div className="flex items-center gap-2">
-            <Calendar className="h-4 w-4" />
+            <Calendar className="size-4 shrink-0" />
             <span className="text-desc2 truncate whitespace-nowrap">
               {formatDateRange(event.start_date, event.end_date)}
             </span>
           </div>
 
           <div className="flex items-center gap-2">
-            <MapPin className="h-4 w-4" />
+            <MapPin className="size-4 shrink-0" />
             <span>{event.venue}</span>
           </div>
         </div>
@@ -125,7 +132,7 @@ export default function MypageEventRecommendCard({
               size={"sm"}
               className="bg-destructive hover:bg-destructive/80"
               onClick={() => handleDeletePlanClick()}
-              disabled={isDeletePlanLoading}
+              disabled={isDeletePlanPending}
             >
               일정에서 제거
             </Button>

--- a/src/components/mypage/MypageEventSectionCard.tsx
+++ b/src/components/mypage/MypageEventSectionCard.tsx
@@ -4,16 +4,17 @@ import MypageAgendaCard from "@/components/mypage/MypageAgendaCard";
 import MypageLikedCard from "@/components/mypage/MypageLikedCard";
 import MypageEventCardSkeleton from "@/components/common/skeleton/MypageEventCardSkeleton";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
-import { Bookmark, Heart, LucideIcon } from "lucide-react";
+import { Bookmark, Heart, LucideIcon, PlusCircle } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { motion, AnimatePresence, Variants } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIsDesktop } from "@/hooks/useIsDesktop";
 import { Event, EventPlanWithEvent, MypageDisplayEvent } from "@/types/common";
 import { parseSafeDate } from "@/utils/date";
 import { format } from "date-fns";
 import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 const ICON_MAP: Record<string, LucideIcon> = {
   bookmark: Bookmark,
@@ -33,6 +34,27 @@ interface MypageEventSectionCardProps {
   events?: (Event | EventPlanWithEvent)[];
 }
 
+interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+const formatToMypageEvent = (
+  item: Event | EventPlanWithEvent,
+): MypageDisplayEvent => {
+  if ("event" in item) {
+    return {
+      ...item.event,
+      plan_id: item.id,
+      visit_date: item.visit_date ?? undefined,
+    };
+  }
+  return item as MypageDisplayEvent;
+};
+
 export default function MypageEventSectionCard({
   title,
   iconName,
@@ -51,26 +73,24 @@ export default function MypageEventSectionCard({
   const Icon = ICON_MAP[iconName];
   const SelectedCard = EVENT_CARD_COMPONENTS[iconName];
 
-  const formattedEvents: MypageDisplayEvent[] = events.map((item) => {
-    if ("event" in item) {
-      return {
-        ...item.event,
-        plan_id: item.id,
-        visit_date: item.visit_date ?? undefined,
-      };
-    }
-    return item as MypageDisplayEvent;
-  });
+  const formattedEvents = useMemo(
+    () => events.map(formatToMypageEvent),
+    [events],
+  );
 
-  const slicedEvents = formattedEvents.slice(0, visibleCount);
+  const slicedEvents = useMemo(
+    () => formattedEvents.slice(0, visibleCount),
+    [formattedEvents, visibleCount],
+  );
 
   const hasMore = visibleCount < formattedEvents.length;
 
   const handleLoadMore = useCallback(() => {
-    if (hasMore) {
-      setVisibleCount((prev) => prev + LIST_NUMBER);
-    }
-  }, [hasMore]);
+    setVisibleCount((prev) => {
+      if (prev >= formattedEvents.length) return prev;
+      return prev + LIST_NUMBER;
+    });
+  }, [formattedEvents.length]);
 
   // 일정, 관심 목록에서 행사 클릭시 달력에서 해당 날짜 선택하는 함수
   const handleEventClick = (dateString: string) => {
@@ -89,7 +109,7 @@ export default function MypageEventSectionCard({
     if (!isDesktop || !hasMore) return;
 
     const viewport = scrollAreaRef.current?.querySelector(
-      '[data-slot="scroll-area-viewport"]',
+      "[data-radix-scroll-area-viewport]",
     );
 
     const observer = new IntersectionObserver(
@@ -100,7 +120,7 @@ export default function MypageEventSectionCard({
       },
       {
         root: viewport, // 브라우저가 아닌 ScrollArea를 기준으로 감지
-        threshold: 0.5,
+        threshold: 0.1,
         rootMargin: "20px",
       },
     );
@@ -110,7 +130,7 @@ export default function MypageEventSectionCard({
     }
 
     return () => observer.disconnect();
-  }, [isDesktop, hasMore, handleLoadMore, visibleCount]);
+  }, [isDesktop, hasMore, handleLoadMore]);
 
   const containerVariants: Variants = {
     hidden: { opacity: 0 },
@@ -132,7 +152,7 @@ export default function MypageEventSectionCard({
   };
 
   return (
-    <Card className="flex h-full flex-col gap-2 rounded-2xl">
+    <Card className="flex flex-col gap-2 rounded-2xl md:h-full md:min-h-0 md:flex-1">
       <CardHeader className="shrink-0">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -146,7 +166,7 @@ export default function MypageEventSectionCard({
           <div className="flex w-full flex-col gap-1">
             {isLoading ? (
               <div className="flex flex-col gap-1 py-1">
-                {Array.from({ length: 3 }).map((_, i) => (
+                {Array.from({ length: LIST_NUMBER }).map((_, i) => (
                   <MypageEventCardSkeleton key={`skeleton-${i}`} />
                 ))}
               </div>
@@ -177,9 +197,21 @@ export default function MypageEventSectionCard({
                     ))}
                   </AnimatePresence>
                 ) : (
-                  <div className="text-etc text-desc2 py-4 text-center">
-                    행사를 추가해 보아요
-                  </div>
+                  <EmptyStateView
+                    icon={iconName === "bookmark" ? Bookmark : Heart}
+                    title={
+                      iconName === "bookmark"
+                        ? "아직 확정된 일정이 없어요"
+                        : "관심 목록이 비어있어요"
+                    }
+                    description={
+                      iconName === "bookmark"
+                        ? "가고 싶은 행사를 일정에 추가해 보세요."
+                        : "관심이 가는 행사를 찜해 보세요."
+                    }
+                    actionLabel="행사 찾으러 가기"
+                    onAction={() => router.push("/map")}
+                  />
                 )}
                 <div ref={observerRef} className="w-full">
                   {hasMore && !isDesktop && (
@@ -209,5 +241,36 @@ export default function MypageEventSectionCard({
         </ScrollArea>
       </CardContent>
     </Card>
+  );
+}
+
+function EmptyStateView({
+  icon: Icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-12 text-center">
+      <div className="bg-muted mb-4 flex size-12 items-center justify-center rounded-full">
+        <Icon className="text-etc size-6" strokeWidth={1.5} />
+      </div>
+      <div className="text-desc1 mb-1 font-bold break-keep">{title}</div>
+      <p className="text-etc text-caption mb-6 leading-relaxed break-keep">
+        {description}
+      </p>
+      {actionLabel && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="rounded-2xl border-dashed px-6"
+          onClick={onAction}
+        >
+          <PlusCircle className="mr-2 size-4" />
+          {actionLabel}
+        </Button>
+      )}
+    </div>
   );
 }

--- a/src/components/mypage/MypageLikedCard.tsx
+++ b/src/components/mypage/MypageLikedCard.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { useEventLike } from "@/hooks/mutations/useEventLike";
 import { CATEGORY_NAME_MAP } from "@/lib/constants";
 import { cn } from "@/lib/utils";
-import { MypageDisplayEvent } from "@/types/common";
+import { CategoryId, MypageDisplayEvent } from "@/types/common";
 import { calculateDDay, formatDateRange } from "@/utils/date";
 import { Calendar, Heart } from "lucide-react";
 
@@ -12,8 +12,6 @@ interface MypageLikedCardProps {
   onClick?: () => void;
   onDetailClick?: (eventId: string) => void;
 }
-
-export type CategoryKey = keyof typeof CATEGORY_NAME_MAP;
 
 export default function MypageLikedCard({
   event,
@@ -44,16 +42,16 @@ export default function MypageLikedCard({
       <div className="flex items-center justify-between">
         <div className="flex gap-2">
           {event.categories?.map((category) => {
-            const categoryLabel =
-              CATEGORY_NAME_MAP[category as CategoryKey] || "기타";
+            const label =
+              CATEGORY_NAME_MAP[category as CategoryId] || "기타";
 
             return (
               <Badge
                 key={category}
                 className="shrink-0 rounded-sm"
-                variant={categoryLabel}
+                variant={label}
               >
-                {CATEGORY_NAME_MAP[category as CategoryKey] || "기타"}
+                {label}
               </Badge>
             );
           })}

--- a/src/components/mypage/MypageLikedCard.tsx
+++ b/src/components/mypage/MypageLikedCard.tsx
@@ -40,10 +40,9 @@ export default function MypageLikedCard({
       onClick={handleCardClick}
     >
       <div className="flex items-center justify-between">
-        <div className="flex gap-2">
+        <div className="flex h-6 min-w-0 flex-1 flex-wrap gap-1 overflow-hidden">
           {event.categories?.map((category) => {
-            const label =
-              CATEGORY_NAME_MAP[category as CategoryId] || "기타";
+            const label = CATEGORY_NAME_MAP[category as CategoryId] || "기타";
 
             return (
               <Badge
@@ -57,8 +56,10 @@ export default function MypageLikedCard({
           })}
         </div>
 
-        <div className="flex gap-2">
-          <div className="text-desc2 text-symbol-sky font-semibold">{dDay}</div>
+        <div className="flex shrink-0 items-center gap-2">
+          <div className="text-desc2 text-symbol-sky font-semibold whitespace-nowrap">
+            {dDay}
+          </div>
           <Button
             className="flex size-5 items-center"
             variant="ghost"

--- a/src/components/mypage/MypageProfileEditForm.tsx
+++ b/src/components/mypage/MypageProfileEditForm.tsx
@@ -101,6 +101,7 @@ export default function MypageProfileEditForm({
 
     if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
       toast.error("지원하지 않는 파일 형식입니다. (JPG, PNG, WebP만 가능)");
+      e.target.value = "";
       return;
     }
 

--- a/src/components/mypage/MypageProfileEditForm.tsx
+++ b/src/components/mypage/MypageProfileEditForm.tsx
@@ -30,6 +30,10 @@ interface MypageProfileEditFormProps {
   onSuccess: () => void;
 }
 
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const MAX_FILE_SIZE_MB = 2;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
 export default function MypageProfileEditForm({
   profile,
   open,
@@ -70,14 +74,12 @@ export default function MypageProfileEditForm({
   }, [previewUrl]);
 
   const displayImageUrl = previewUrl || profile.avatar_url;
-
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const isChanged =
     nickname !== (profile.nickname || "") ||
     email !== (profile.email || "") ||
     avatarFile !== null;
-
   const isFormInvalid =
     !!errors.nickname || !!errors.email || !nickname.trim() || !email.trim();
 
@@ -97,26 +99,20 @@ export default function MypageProfileEditForm({
     const file = e.target.files?.[0];
     if (!file) return;
 
-    const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
-    if (!allowedTypes.includes(file.type)) {
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
       toast.error("지원하지 않는 파일 형식입니다. (JPG, PNG, WebP만 가능)");
       return;
     }
 
-    const options = {
-      maxSizeMB: 2,
-      useWebWorker: true,
-    };
-    const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB 제한 설정 (1MB = 1024 * 1024 bytes)
-
     try {
       toast.loading("이미지 최적화 중...", { id: "compressing" });
-
-      const compressedFile = await imageCompression(file, options);
-
+      const compressedFile = await imageCompression(file, {
+        maxSizeMB: MAX_FILE_SIZE_MB,
+        useWebWorker: true,
+      });
       toast.dismiss("compressing");
 
-      if (compressedFile.size > MAX_FILE_SIZE) {
+      if (compressedFile.size > MAX_FILE_SIZE_BYTES) {
         toast.error("최적화 후에도 파일이 너무 큽니다.");
         return;
       }
@@ -203,101 +199,88 @@ export default function MypageProfileEditForm({
   };
 
   return (
-    <div className="grid gap-6 py-4">
-      <DialogHeader>
-        <DialogTitle className="text-title1 font-bold">프로필 관리</DialogTitle>
-        <DialogDescription>
-          수정하고자 하는 닉네임과 이메일을 입력하세요.
-        </DialogDescription>
+    <div className="grid gap-6">
+      <DialogHeader className="relative flex flex-col items-start justify-center">
+        <div className="flex flex-col items-start gap-1 text-left">
+          <DialogTitle className="text-title1 font-bold">
+            프로필 관리
+          </DialogTitle>
+          <DialogDescription>
+            수정하고자 하는 닉네임과 이메일을 입력하세요.
+          </DialogDescription>
+        </div>
+        <Button
+          aria-label="닫기"
+          variant="ghost"
+          size="icon"
+          onClick={onSuccess}
+          className="absolute top-0 right-0 size-6 shrink-0"
+        >
+          <X className="size-4" />
+        </Button>
       </DialogHeader>
 
-      <div className="grid gap-6 py-4">
-        <div className="flex flex-col items-center gap-4">
-          <div className="relative size-30 md:size-20">
-            <div className="bg-etc-sub relative h-full w-full overflow-hidden rounded-full border">
-              {displayImageUrl ? (
-                <Image
-                  src={displayImageUrl}
-                  alt="프로필"
-                  fill
-                  className="object-cover"
-                />
-              ) : (
-                <div className="flex h-full w-full items-center justify-center">
-                  <User strokeWidth={1.2} className="text-etc h-10 w-10" />
-                </div>
-              )}
-            </div>
-            {previewUrl && (
-              <button
-                type="button"
-                onClick={handleRemovePreview}
-                className="transition-hover hover:bg-etc-sub absolute -top-1 -right-1 z-10 flex size-7 cursor-pointer items-center justify-center rounded-full border bg-white"
-              >
-                <X size={16} />
-              </button>
+      <section className="flex flex-col items-center gap-4">
+        <div className="relative size-24 md:size-20">
+          <div className="bg-etc-sub relative h-full w-full overflow-hidden rounded-full border">
+            {displayImageUrl ? (
+              <Image
+                src={displayImageUrl}
+                alt="프로필"
+                fill
+                className="object-cover"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <User strokeWidth={1.2} className="text-etc h-10 w-10" />
+              </div>
             )}
           </div>
-
-          {/* 파일 업로드를 위한 투명 input */}
-          <input
-            type="file"
-            ref={fileInputRef}
-            className="hidden"
-            accept="image/jpeg, image/png, image/webp"
-            onChange={handleFileChange}
-          />
-
-          <Button
-            variant="outline"
-            onClick={() => fileInputRef.current?.click()}
-            className="hover:bg-muted w-full rounded-2xl font-bold"
-          >
-            이미지 변경
-          </Button>
+          {previewUrl && (
+            <button
+              type="button"
+              onClick={handleRemovePreview}
+              className="transition-hover hover:bg-etc-sub absolute -top-1 -right-1 z-10 flex size-7 cursor-pointer items-center justify-center rounded-full border bg-white"
+            >
+              <X size={16} />
+            </button>
+          )}
         </div>
 
-        <div className="space-y-4">
-          <div className="grid gap-2">
-            <Label htmlFor="nickname" className="text-desc2 font-semibold">
-              닉네임
-            </Label>
-            <Input
-              id="nickname"
-              value={nickname}
-              onChange={handleNicknameChange}
-              className={cn(
-                "rounded-2xl outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
-                "focus-visible:border-symbol-sky focus-visible:border-2",
-                errors.nickname &&
-                  "border-destructive focus-visible:border-destructive border-2",
-              )}
-            />
-            {errors.nickname && (
-              <p className="text-destructive text-caption">{errors.nickname}</p>
-            )}
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="email" className="text-desc2 font-semibold">
-              이메일
-            </Label>
-            <Input
-              id="email"
-              value={email}
-              onChange={handleEmailChange}
-              className={cn(
-                "rounded-2xl outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
-                "focus-visible:border-symbol-sky border focus-visible:border-2",
-                errors.email &&
-                  "border-destructive focus-visible:border-destructive border-2",
-              )}
-            />
-            {errors.email && (
-              <p className="text-destructive text-caption">{errors.email}</p>
-            )}
-          </div>
-        </div>
-      </div>
+        {/* 파일 업로드를 위한 투명 input */}
+        <input
+          type="file"
+          ref={fileInputRef}
+          className="hidden"
+          accept="image/jpeg, image/png, image/webp"
+          onChange={handleFileChange}
+        />
+
+        <Button
+          variant="outline"
+          onClick={() => fileInputRef.current?.click()}
+          className="hover:bg-muted w-full rounded-2xl font-bold"
+        >
+          이미지 변경
+        </Button>
+      </section>
+
+      <section className="space-y-4">
+        <FormInputField
+          id="nickname"
+          label="닉네임"
+          value={nickname}
+          error={errors.nickname}
+          onChange={handleNicknameChange}
+        />
+        <FormInputField
+          id="email"
+          label="이메일"
+          value={email}
+          error={errors.email}
+          onChange={handleEmailChange}
+        />
+      </section>
 
       <DialogFooter>
         <div className="flex w-full flex-col items-center justify-center gap-4">
@@ -318,6 +301,40 @@ export default function MypageProfileEditForm({
           </button>
         </div>
       </DialogFooter>
+    </div>
+  );
+}
+
+function FormInputField({
+  id,
+  label,
+  value,
+  error,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  error?: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id} className="text-desc2 font-semibold">
+        {label}
+      </Label>
+      <Input
+        id={id}
+        value={value}
+        onChange={onChange}
+        className={cn(
+          "rounded-2xl border-2 transition-all outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+          error
+            ? "border-destructive focus-visible:border-destructive"
+            : "focus-visible:border-symbol-sky",
+        )}
+      />
+      {error && <p className="text-destructive text-caption">{error}</p>}
     </div>
   );
 }

--- a/src/components/mypage/MypageRecommendSection.tsx
+++ b/src/components/mypage/MypageRecommendSection.tsx
@@ -18,23 +18,27 @@ interface MypageRecommendSectionProps {
 export default function MypageRecommendSection({
   recommendEventData,
   isLoading,
-  likedEvents,
-  plannedEvents,
+  likedEvents = [],
+  plannedEvents = [],
   onDetailClick,
 }: MypageRecommendSectionProps) {
-  const isLiked = useMemo(() => {
-    if (!recommendEventData) return false;
-    return (likedEvents ?? []).some(
-      (event) => event.id === recommendEventData.id,
-    );
-  }, [likedEvents, recommendEventData]);
+  const likedEventIds = useMemo(
+    () => new Set(likedEvents.map((e) => e.id)),
+    [likedEvents],
+  );
+  const planMap = useMemo(
+    () => new Map(plannedEvents.map((p) => [p.event.id, p])),
+    [plannedEvents],
+  );
 
-  const matchedPlan = useMemo(() => {
-    if (!recommendEventData) return undefined;
-    return (plannedEvents ?? []).find(
-      (plan) => plan.event.id === recommendEventData.id,
-    );
-  }, [plannedEvents, recommendEventData]);
+  const { isLiked, matchedPlan } = useMemo(() => {
+    if (!recommendEventData) return { isLiked: false, matchedPlan: undefined };
+
+    return {
+      isLiked: likedEventIds.has(recommendEventData.id),
+      matchedPlan: planMap.get(recommendEventData.id),
+    };
+  }, [recommendEventData, likedEventIds, planMap]);
 
   const isPlanned = !!matchedPlan;
   const matchedPlanId = matchedPlan?.id;

--- a/src/components/mypage/MypageSelectedDateEventsCard.tsx
+++ b/src/components/mypage/MypageSelectedDateEventsCard.tsx
@@ -1,50 +1,45 @@
 import MypageAgendaCard from "@/components/mypage/MypageAgendaCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { motion, Variants } from "framer-motion";
-import { MypageDisplayEvent } from "@/types/common";
+import { CategoryId, MypageDisplayEvent } from "@/types/common";
 import { cn } from "@/lib/utils";
 import { CALENDAR_CATEGORY_STYLES, CATEGORY_NAME_MAP } from "@/lib/constants";
-import { formatDate } from "@/utils/date";
 import MypageLikedCard from "@/components/mypage/MypageLikedCard";
 
 interface MypageSelectedDateEventsCardProps {
-  selectedDate: Date | null | undefined;
   events: MypageDisplayEvent[];
   viewMode: "plan" | "like";
   onDetailClick?: (eventId: string) => void;
 }
 
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+    },
+  },
+};
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      type: "spring",
+      stiffness: 300,
+      damping: 24,
+    },
+  },
+};
+
 export default function MypageSelectedDateEventsCard({
   events,
-  selectedDate,
   viewMode,
   onDetailClick,
 }: MypageSelectedDateEventsCardProps) {
-  const formattedSelectedDate = formatDate(selectedDate);
-
-  const containerVariants: Variants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.3,
-      },
-    },
-  };
-
-  const itemVariants: Variants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        type: "spring",
-        stiffness: 300,
-        damping: 24,
-      },
-    },
-  };
-
   return (
     <motion.div
       variants={containerVariants}
@@ -52,37 +47,37 @@ export default function MypageSelectedDateEventsCard({
       animate="visible"
       className="flex flex-col gap-4"
     >
-      {events.map((event, index) => {
-        const categoryKey = event
-          .categories[0] as keyof typeof CATEGORY_NAME_MAP;
-        const koreanName = CATEGORY_NAME_MAP[categoryKey] || "기타";
-        const style =
+      {events.map((event) => {
+        const categoryId = (event.categories?.[0] || "etc") as CategoryId;
+        const koreanName = CATEGORY_NAME_MAP[categoryId] || "기타";
+        const dotColorClass = (
           CALENDAR_CATEGORY_STYLES[koreanName] ||
-          CALENDAR_CATEGORY_STYLES["기타"];
-
-        const dotColorClass = style.dot;
+          CALENDAR_CATEGORY_STYLES["기타"]
+        ).dot;
 
         return (
-          <motion.div key={event.id} variants={itemVariants} layout>
-            <div key={index} className="flex gap-2">
-              <div className={cn("mt-2 size-2 rounded-full", dotColorClass)} />
-              <Card className="min-w-0 flex-1 rounded-2xl shadow-sm">
-                <CardContent>
-                  {viewMode === "plan" ? (
-                    <MypageAgendaCard
-                      event={event}
-                      selectedDate={formattedSelectedDate}
-                      onDetailClick={onDetailClick}
-                    />
-                  ) : (
-                    <MypageLikedCard
-                      event={event}
-                      onDetailClick={onDetailClick}
-                    />
-                  )}
-                </CardContent>
-              </Card>
-            </div>
+          <motion.div
+            key={event.id}
+            variants={itemVariants}
+            layout
+            className="flex gap-2"
+          >
+            <div className={cn("mt-2 size-2 rounded-full", dotColorClass)} />
+            <Card className="min-w-0 flex-1 rounded-2xl shadow-sm">
+              <CardContent>
+                {viewMode === "plan" ? (
+                  <MypageAgendaCard
+                    event={event}
+                    onDetailClick={onDetailClick}
+                  />
+                ) : (
+                  <MypageLikedCard
+                    event={event}
+                    onDetailClick={onDetailClick}
+                  />
+                )}
+              </CardContent>
+            </Card>
           </motion.div>
         );
       })}

--- a/src/hooks/queries/useEventsData.ts
+++ b/src/hooks/queries/useEventsData.ts
@@ -4,14 +4,16 @@ import { useQuery } from "@tanstack/react-query";
 import { createClient } from "@/utils/supabase/client";
 import { fetchEvents } from "@/lib/api/events";
 import { QUERY_KEYS } from "@/lib/constants";
-import { Event } from "@/types/common";
+import { Event, RawEvent } from "@/types/common";
+import { transformEvent } from "@/utils/transform";
 
 export function useEventsData() {
   const supabase = createClient();
 
-  return useQuery<Event[]>({
+  return useQuery<RawEvent[], Error, Event[]>({
     queryKey: QUERY_KEYS.EVENTS,
     queryFn: () => fetchEvents(supabase),
+    select: (data) => data.map(transformEvent),
     staleTime: Infinity,
     gcTime: 1000 * 60 * 30,
   });

--- a/src/hooks/queries/useLikedEventsData.ts
+++ b/src/hooks/queries/useLikedEventsData.ts
@@ -5,16 +5,21 @@ import { createClient } from "@/utils/supabase/client";
 import { fetchLikedEvents } from "@/lib/api/events";
 import { QUERY_KEYS } from "@/lib/constants";
 import { useUserData } from "./useUserData";
-import { Event } from "@/types/common";
+import { Event, LikedEventRaw } from "@/types/common";
+import { transformEvent } from "@/utils/transform";
 
 export function useLikedEventsData() {
   const { data: user } = useUserData();
   const supabase = createClient();
 
-  return useQuery<Event[]>({
+  return useQuery<LikedEventRaw[], Error, Event[]>({
     queryKey: QUERY_KEYS.LIKED_EVENTS(user?.id),
     queryFn: () => fetchLikedEvents(supabase, user!.id),
     enabled: !!user?.id,
+    select: (rawData) =>
+      rawData
+        .map((item) => transformEvent(item.events))
+        .filter((event): event is Event => event !== null),
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 30,
   });

--- a/src/hooks/queries/usePlannedEventsData.ts
+++ b/src/hooks/queries/usePlannedEventsData.ts
@@ -4,17 +4,23 @@ import { useQuery } from "@tanstack/react-query";
 import { createClient } from "@/utils/supabase/client";
 import { fetchPlannedEvents } from "@/lib/api/eventPlans";
 import { QUERY_KEYS } from "@/lib/constants";
-import { EventPlanWithEvent } from "@/types/common";
+import { RawEventPlan, EventPlanWithEvent } from "@/types/common";
 import { useUserData } from "@/hooks/queries/useUserData";
+import { transformEvent } from "@/utils/transform";
 
 export function usePlannedEventsData() {
   const { data: user } = useUserData();
   const supabase = createClient();
 
-  return useQuery<EventPlanWithEvent[]>({
+  return useQuery<RawEventPlan[], Error, EventPlanWithEvent[]>({
     queryKey: QUERY_KEYS.EVENT_PLANS(user?.id),
     queryFn: () => fetchPlannedEvents(supabase, user!.id),
     enabled: !!user?.id,
+    select: (rawData) =>
+      rawData.map((plan) => ({
+        ...plan,
+        event: transformEvent(plan.event),
+      })),
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 30,
   });

--- a/src/lib/api/eventPlans.ts
+++ b/src/lib/api/eventPlans.ts
@@ -1,8 +1,7 @@
 import { SupabaseClient } from "@supabase/supabase-js";
-import { Database, Tables } from "@/types/supabase";
+import { Database } from "@/types/supabase";
 import { format } from "date-fns";
-import { transformEvent } from "@/utils/transform";
-import { EventPlanWithEvent } from "@/types/common";
+import { RawEventPlan } from "@/types/common";
 
 export interface AddEventPlanParams {
   userId: string;
@@ -13,7 +12,7 @@ export interface AddEventPlanParams {
 export async function fetchPlannedEvents(
   supabase: SupabaseClient<Database>,
   userId: string,
-): Promise<EventPlanWithEvent[]> {
+): Promise<RawEventPlan[]> {
   const today = format(new Date(), "yyyy-MM-dd");
   const { data, error } = await supabase
     .from("event_plans")
@@ -28,10 +27,7 @@ export async function fetchPlannedEvents(
     .order("visit_date", { ascending: true });
 
   if (error) throw new Error(error.message);
-  return (data || []).map((plan) => ({
-    ...plan,
-    event: transformEvent(plan.event as Tables<"events">),
-  })) as EventPlanWithEvent[];
+  return (data as unknown as RawEventPlan[]) || [];
 }
 
 export async function addEventPlan(

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -1,32 +1,13 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { Database } from "@/types/supabase";
-import { Category, Event } from "@/types/common";
 import { format as formatDate } from "date-fns";
-import { transformEvent } from "@/utils/transform";
-
-export type EventCategory = Exclude<Category, "전체">;
+import { LikedEventRaw, RawEvent } from "@/types/common";
 
 const getToday = () => formatDate(new Date(), "yyyy-MM-dd");
 
-export async function fetchEventById(
-  supabase: SupabaseClient<Database>,
-  eventId: string,
-): Promise<Event | null> {
-  const { data, error } = await supabase
-    .from("events")
-    .select("*")
-    .eq("id", eventId)
-    .maybeSingle();
-
-  if (error) throw new Error(error.message);
-  if (!data) return null;
-
-  return transformEvent(data);
-}
-
 export async function fetchEvents(
   supabase: SupabaseClient<Database>,
-): Promise<Event[]> {
+): Promise<RawEvent[]> {
   const { data, error } = await supabase
     .from("events")
     .select("*")
@@ -35,13 +16,13 @@ export async function fetchEvents(
 
   if (error) throw new Error(error.message);
 
-  return (data || []).map(transformEvent);
+  return data || [];
 }
 
 export async function fetchLikedEvents(
   supabase: SupabaseClient<Database>,
   userId: string,
-): Promise<Event[]> {
+): Promise<LikedEventRaw[]> {
   const { data, error } = await supabase
     .from("event_likes")
     .select(
@@ -55,9 +36,5 @@ export async function fetchLikedEvents(
 
   if (error) throw new Error(error.message);
 
-  // Supabase 조인 결과는 [{ events: {...} }, { events: {...} }] 형태
-  // 사용하기 편하게 [ {...}, {...} ] 형태로 가공하여 반환
-  return (data || [])
-    .map((item) => transformEvent(item.events))
-    .filter((event) => event !== null);
+  return data || [];
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -15,7 +15,8 @@ export async function proxy(request: NextRequest) {
     if (!user) {
       const loginUrl = new URL("/login", request.url);
       loginUrl.searchParams.set("error", "unauthorized");
-      loginUrl.searchParams.set("next", request.nextUrl.pathname);
+      const fullPath = request.nextUrl.pathname + request.nextUrl.search;
+      loginUrl.searchParams.set("next", fullPath);
 
       const redirectResponse = NextResponse.redirect(loginUrl);
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -47,12 +47,15 @@ export interface RecommendCardConfigItem {
 // 행사 카드 관련 타입
 // ==============================
 export type RawEvent = Tables<"events">;
+
 export type LikedEventRaw = {
   events: RawEvent;
 };
+
 export type RawEventPlan = Tables<"event_plans"> & {
   event: RawEvent;
 };
+
 export type EventPlanWithEvent = Tables<"event_plans"> & {
   event: Event;
 };
@@ -64,6 +67,7 @@ export type Event = Omit<Tables<"events">, "categories" | "visitor_count"> & {
   categories: string[];
   visitor_count: string;
 };
+
 export type MypageDisplayEvent = Event & {
   plan_id?: string; // 일정 고유 ID
   visit_date?: string; // 방문일

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -46,12 +46,27 @@ export interface RecommendCardConfigItem {
 // ==============================
 // 행사 카드 관련 타입
 // ==============================
+export type RawEvent = Tables<"events">;
+export type LikedEventRaw = {
+  events: RawEvent;
+};
+export type RawEventPlan = Tables<"event_plans"> & {
+  event: RawEvent;
+};
+export type EventPlanWithEvent = Tables<"event_plans"> & {
+  event: Event;
+};
+
 export type Event = Omit<Tables<"events">, "categories" | "visitor_count"> & {
   // 테이블에서 jsonb 사용하게 되면서 [0]처럼 인덱스 접근 불가
   // type Event를 만들때 categories의 타입을 string[]으로 변경하여 사용
   // 방문객 수를 1,000,000명 처럼 ,로 끊고 string으로 변경하여 사용
   categories: string[];
   visitor_count: string;
+};
+export type MypageDisplayEvent = Event & {
+  plan_id?: string; // 일정 고유 ID
+  visit_date?: string; // 방문일
 };
 
 export interface EventCardItem {
@@ -72,15 +87,6 @@ export interface EventWeatherInfoCardItem {
   wet: string;
   fineDust: string;
 }
-
-export type MypageDisplayEvent = Event & {
-  plan_id?: string; // 일정 고유 ID
-  visit_date?: string; // 방문일
-};
-
-export type EventPlanWithEvent = Tables<"event_plans"> & {
-  event: Event;
-};
 
 // ==============================
 // 날씨 카드 관련 타입

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -1,0 +1,112 @@
+import { MypageDisplayEvent } from "@/types/common";
+import { addDays, parseISO, startOfDay, startOfWeek } from "date-fns";
+
+export interface ProcessedEvent extends MypageDisplayEvent {
+  _start: Date;
+  _end: Date;
+  _id: string;
+}
+
+export interface GetWeeklyEventSlotsReturn {
+  processedEvents: ProcessedEvent[];
+  weeklySlots: Record<string, Record<string, number>>;
+  dailyEventsMap: Record<string, ProcessedEvent[]>;
+}
+
+// 주차별 행사의 슬롯 번호 계산하는 함수
+export const getWeeklyEventSlots = (
+  events: MypageDisplayEvent[],
+): GetWeeklyEventSlotsReturn => {
+  if (events.length === 0) {
+    return {
+      processedEvents: [],
+      weeklySlots: {},
+      dailyEventsMap: {},
+    };
+  }
+
+  // 데이터 전처리(파싱, Date 객체 변환) 및 정렬
+  const processedEvents = events
+    .map((event) => ({
+      ...event,
+      _start: startOfDay(parseISO(event.start_date)),
+      _end: startOfDay(parseISO(event.end_date)),
+      _id: String(event.plan_id || event.id),
+    }))
+    .sort((a, b) => {
+      const diff = a._start.getTime() - b._start.getTime();
+      if (diff !== 0) return diff;
+      // 시작일이 같으면 기간이 긴 순서대로
+      return (
+        b._end.getTime() -
+        b._start.getTime() -
+        (a._end.getTime() - a._start.getTime())
+      );
+    });
+
+  //날짜별 이벤트 매핑
+  const dailyEventsMap: Record<string, ProcessedEvent[]> = {};
+
+  processedEvents.forEach((event) => {
+    let current = event._start;
+    while (current <= event._end) {
+      const dateKey = current.getTime().toString();
+      if (!dailyEventsMap[dateKey]) dailyEventsMap[dateKey] = [];
+      dailyEventsMap[dateKey].push(event);
+      current = addDays(current, 1);
+    }
+  });
+
+  // 주차별로 이벤트 그룹화
+  const weekBuckets: Record<string, typeof processedEvents> = {};
+
+  processedEvents.forEach((event) => {
+    let currentWeekStart = startOfWeek(event._start);
+    const lastWeekStart = startOfWeek(event._end);
+
+    while (currentWeekStart <= lastWeekStart) {
+      const weekKey = currentWeekStart.getTime().toString();
+      if (!weekBuckets[weekKey]) weekBuckets[weekKey] = [];
+      weekBuckets[weekKey].push(event);
+      currentWeekStart = addDays(currentWeekStart, 7);
+    }
+  });
+
+  // 각 주차별로 슬롯 번호 배정
+  const weeklySlots: Record<string, Record<string, number>> = {};
+
+  Object.entries(weekBuckets).forEach(([weekKey, weekEvents]) => {
+    const slots: Record<string, number> = {}; //{행사 ID, 슬롯 번호}
+    const occupation: { start: number; end: number }[][] = [];
+
+    weekEvents.forEach((event) => {
+      const startTs = event._start.getTime();
+      const endTs = event._end.getTime();
+      let assignedSlot = -1;
+
+      // 이미 정렬된 상태이므로 순서대로 슬롯 찾기
+      for (let i = 0; i < occupation.length; i++) {
+        const hasOverlap = occupation[i].some(
+          (occ) => startTs <= occ.end && endTs >= occ.start,
+        );
+        if (!hasOverlap) {
+          assignedSlot = i;
+          break;
+        }
+      }
+
+      // 들어갈 층이 없는 경우 새 층을 추가하고 push
+      if (assignedSlot === -1) {
+        assignedSlot = occupation.length;
+        occupation.push([]);
+      }
+
+      occupation[assignedSlot].push({ start: startTs, end: endTs });
+      slots[event._id] = assignedSlot;
+    });
+
+    weeklySlots[weekKey] = slots;
+  });
+
+  return { processedEvents, weeklySlots, dailyEventsMap };
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -2,12 +2,18 @@ export const validateNickname = (nickname: string) => {
   if (!nickname.trim()) return "닉네임을 입력해 주세요.";
   if (nickname.length < 2) return "닉네임은 최소 2글자 이상이어야 합니다.";
   if (nickname.length > 8) return "닉네임은 최대 8글자 이하여야 합니다.";
+
+  const nicknameRegex = /^[a-zA-Z0-9가-힣]+$/;
+  if (!nicknameRegex.test(nickname)) {
+    return "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.";
+  }
+
   return "";
 };
 
 export const validateEmail = (email: string) => {
   if (!email.trim()) return "이메일을 입력해 주세요.";
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // [문자]@[문자].[문자] 형태 정규식
+  const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   if (!emailRegex.test(email)) return "올바른 이메일 형식이 아닙니다.";
   return "";
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -13,7 +13,8 @@ export const validateNickname = (nickname: string) => {
 
 export const validateEmail = (email: string) => {
   if (!email.trim()) return "이메일을 입력해 주세요.";
-  const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  const emailRegex =
+    /^(?!.*\.\.)[a-zA-Z0-9._%+-]+@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
   if (!emailRegex.test(email)) return "올바른 이메일 형식이 아닙니다.";
   return "";
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/remind",
+      "schedule": "0 0 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #48 

<br />

## 📝 작업 내용

**사용하는 부분 변경하지 않고 마이페이지 관련 코드 리팩토링 진행**
필요없는 코드 정리, 여러 곳에서 사용되는 타입은 common.ts에 정리, 멘토링 피드백 반영(api에선 raw 데이터를 받아서 React Query로 전달, React Query에서 select 사용하여 데이터 가공), .some처럼 리소스 많이 사용하는 연산 대신 Set, Map과 has, get 메서드 사용하는 방식으로 변경, 반복되는 코드 수정

---

**방문일 선택 모달에서 날짜 선택 안 하면 버튼 비활성화 및 안내문구 출력**
<img width="649" height="643" alt="image" src="https://github.com/user-attachments/assets/31f0fe6f-90bc-4c61-9574-7a51faf3c8e4" />
<img width="605" height="609" alt="image" src="https://github.com/user-attachments/assets/fa7e08b5-a4fc-4790-9090-3a103fbfba47" />


---

**모바일 너비에서 드로워 펴서 상세보기 모달 열고 데스크탑 너비로 넓히면 상세보기 모달 + 팝오버 열리던 버그 수정**
이제 상세보기 모달 열리면 드로워, 팝오버는 닫힘

---

**마이페이지 일정 목록, 관심 목록 반응형 md 중단점 근처(약 770px)에서 레이아웃 깨지는거 수정**
<img width="841" height="912" alt="image" src="https://github.com/user-attachments/assets/5372e36f-e5b9-4961-88ff-8647fb53d9d3" />


---

**Verce;에 배포되어 있으니 기존에 만들어 두었던 Cron Job 코드 살려서 방문일 7일 전 리마인드 메일 송신하는 기능 추가**
<img width="321" height="265" alt="image" src="https://github.com/user-attachments/assets/4af8a551-d2b4-4d74-8cea-eaab9f9e9ed6" />
루트 디렉토리에 vercel.json 파일 추가

<img width="1300" height="1120" alt="image" src="https://github.com/user-attachments/assets/aed31b79-2d0d-4e0f-a6f3-228e75767148" />

내 일정 확인하기 버튼 클릭시 갈래말래 서비스의 마이페이지로 이동, 해당일의 팝오버 혹은 드로워를 열음
<img width="1577" height="1394" alt="image" src="https://github.com/user-attachments/assets/f49d2bb4-671c-477f-a708-263f5848fa6b" />
<img width="618" height="945" alt="image" src="https://github.com/user-attachments/assets/6dd334dc-79f7-4465-a6ad-0541e27fedb5" />

만약 사용자가 갈래말래 서비스에서 로그아웃 되어 있는 상태에서 내 일정 확인하기 버튼 클릭하여 갈래말래 서비스로 이동시, 로그인 페이지로 이동함

비로그인 사용자가 로그인 필요한 기능에 접근하려고 할 때 로그인 페이지로 이동시키고, 정상적으로 로그인 완료시 원래 페이지로 돌아가는 기능을 보완하여 비로그인 사용자가 갈래말래 서비스에서 로그아웃 되어 있는 상태에서 내 일정 확인하기 버튼 클릭하여 갈래말래 서비스로 이동하면 로그인 페이지로 이동시키고, 정상적으로 로그인 완료시 마이페이지로 이동되면서 행사 방문일 팝오버 혹은 드로워가 열리도록 함

<img width="1457" height="1386" alt="image" src="https://github.com/user-attachments/assets/30bc9c67-de2b-4728-bb8c-7fa47e0f1266" />
<img width="617" height="78" alt="image" src="https://github.com/user-attachments/assets/5a8ec715-92f0-438a-822e-303a3d7a2e69" />
<img width="1588" height="1384" alt="image" src="https://github.com/user-attachments/assets/7f7e101a-91e8-402b-91ef-654ae2ab0920" />


<br />

## 💬 리뷰 요구사항 ( 선택 )


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 일일 자동 리마인더(크론) 등록 및 방문 중심 알림 발송 지원

* **개선 사항**
  * 마이페이지 레이아웃·로딩 UX 개선(우측 이벤트 지연 로드, 스켈레톤·펄스 페일백, 로딩 제어 개선)
  * 캘린더 일정 배치·주간 슬롯화 도입으로 표시 정확도 향상 및 일별 이벤트 조회 최적화
  * 빈 상태 UI 강화 및 접근성 향상(키보드 포커스, 포괄적 액션)
  * 프로필 이미지 업로드 검증 강화 및 닉네임/이메일 유효성 검사 엄격화
  * 리마인더 전송 흐름·인증 강화 및 발송 결과 리포트 개선
  * 일부 모달/버튼 동작 개선(날짜 선택 안내·확인 버튼 비활성화 로직)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->